### PR TITLE
intervalo (de potas)

### DIFF
--- a/src/vb6compat.cpp
+++ b/src/vb6compat.cpp
@@ -58,11 +58,13 @@ std::string string_format(const std::string fmt_str, ...) {
 }
 
 void InitializeTickCount() {
-	tickCountStart = boost::posix_time::second_clock::local_time();
+
+	tickCountStart = boost::posix_time::microsec_clock::local_time();
 }
 
 std::size_t GetTickCount() {
-	boost::posix_time::time_duration diff = boost::posix_time::second_clock::local_time() - tickCountStart;
+
+	boost::posix_time::time_duration diff =	boost::posix_time::microsec_clock::local_time() - tickCountStart;
 	return diff.total_milliseconds();
 }
 


### PR DESCRIPTION
no andaban porque eran muy rapidos y la resolución de milisegundos no alcanza.
Segun lei, microsec_clock puede que no tenga suficiente resolución en windows, pero en linux deberia andar ok.