### PR TITLE
fix socket close

### DIFF
--- a/src/Sockets.h
+++ b/src/Sockets.h
@@ -42,10 +42,6 @@ inline void WsApiEnviar(dakara::Socket* sctx, std::vector<std::int8_t> data) {
 	return WsApiEnviar(sctx, reinterpret_cast<const char*>(data.data()), data.size());
 }
 
-inline void WsApiEnviar(dakara::Socket* sctx, std::vector<std::uint8_t> data) {
-	return WsApiEnviar(sctx, reinterpret_cast<const char*>(data.data()), data.size());
-}
-
 void WSApiReiniciarSockets();
 
 bool UserIndexSocketValido(int UserIndex);


### PR DESCRIPTION
a veces los sockets se cerraban sin antes haberse flusheado por completo los buffers de libevent, ahora se cierran con el callback del write si esta en closing_ y el buffer esta vacio (o inmediatamente si el buffer esta vacio al cerrarlo)